### PR TITLE
Issue/25

### DIFF
--- a/ec2/asg.tf
+++ b/ec2/asg.tf
@@ -4,7 +4,7 @@ data "template_file" "instance_userdata" {
   vars {
     host_name         = "${local.iaps_role}-001"
     internal_domain   = "${local.internal_domain}"
-    external_domain     = "${local.external_domain}"
+    external_domain   = "${local.external_domain}"
     user_ssm_path     = "/${local.environment-name}/${local.application}/iaps/iaps/iaps_user"
     password_ssm_path = "/${local.environment-name}/${local.application}/iaps/iaps/iaps_password"
   }
@@ -30,6 +30,54 @@ resource "aws_launch_configuration" "iaps" {
   }
 }
 
+resource "aws_launch_template" "iaps" {
+  name_prefix = "${local.environment-name}-${local.application}-iaps-pri-tpl-"
+  description = "Windows IAPS Server Launch Template"
+
+  block_device_mappings {
+    device_name = "/dev/sda1"
+
+    ebs {
+      volume_type = "gp2"
+      volume_size = "${var.ebs_volume_size}"
+    }
+  }
+
+  ebs_optimized = true
+
+  iam_instance_profile {
+    name = "${local.instance_profile}"
+  }
+
+  image_id      = "${local.ami_id}"
+  instance_type = "${var.instance_type}"
+
+  monitoring {
+    enabled = true
+  }
+
+  network_interfaces {
+    associate_public_ip_address = false
+
+    security_groups = [
+      "${local.sg_map_ids["sg_iaps_api_in"]}",
+      "${local.sg_outbound_id}",
+    ]
+  }
+
+  user_data = "${base64encode(data.template_file.instance_userdata.rendered)}"
+
+  tag_specifications {
+    resource_type = "instance"
+    tags          = "${merge(local.tags, map("Name", "${var.environment_name}-${var.project_name}-iaps-ec2"))}"
+  }
+
+  tag_specifications {
+    resource_type = "volume"
+    tags          = "${merge(local.tags, map("Name", "${var.environment_name}-${var.project_name}-iaps-ebs"))}"
+  }
+}
+
 # Hack to merge additional tag into existing map and convert to list for use with asg tags input
 data "null_data_source" "asg-tags" {
   count = "${length(keys(merge(local.tags, map("Name", "${local.environment-name}-${var.project_name}-iaps-asg"))))}"
@@ -51,7 +99,12 @@ resource "aws_autoscaling_group" "iaps" {
   min_size                  = 1
   health_check_grace_period = 300
   health_check_type         = "EC2"
-  launch_configuration      = "${aws_launch_configuration.iaps.name}"
+
+  #launch_configuration      = "${aws_launch_configuration.iaps.name}"
+  launch_template = {
+    id      = "${aws_launch_template.iaps.id}"
+    version = "$Latest"
+  }
 
   target_group_arns = [
     "${aws_lb_target_group.iaps_https.arn}",

--- a/ec2/asg.tf
+++ b/ec2/asg.tf
@@ -10,26 +10,6 @@ data "template_file" "instance_userdata" {
   }
 }
 
-resource "aws_launch_configuration" "iaps" {
-  associate_public_ip_address = false
-  iam_instance_profile        = "${local.instance_profile}"
-  image_id                    = "${local.ami_id}"
-  instance_type               = "${var.instance_type}"
-  name_prefix                 = "${local.environment-name}-${local.application}-iaps-launch-cfg-"
-
-  security_groups = [
-    "${local.sg_map_ids["sg_iaps_api_in"]}",
-    "${local.sg_outbound_id}",
-  ]
-
-  user_data_base64 = "${base64encode(data.template_file.instance_userdata.rendered)}"
-  key_name         = "${local.ssh_deployer_key}"
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
 resource "aws_launch_template" "iaps" {
   name_prefix = "${local.environment-name}-${local.application}-iaps-pri-tpl-"
   description = "Windows IAPS Server Launch Template"

--- a/ec2/backup.tf
+++ b/ec2/backup.tf
@@ -1,0 +1,33 @@
+resource "aws_backup_vault" "iaps_backup_vault" {
+  name = "${var.environment_name}-${var.project_name}-iapsabkup-pri-vlt"
+  tags = "${merge(local.tags, map("Name", "${var.environment_name}-${var.project_name}-iapsbkup-pri-vlt"))}"
+}
+
+resource "aws_backup_plan" "iaps_backup_plan" {
+  name = "${var.environment_name}-${var.project_name}-iapsabkup-pri-pln"
+
+  rule {
+    rule_name         = "IAPS EBS Volume Backup"
+    target_vault_name = "${aws_backup_vault.iaps_backup_vault.name}"
+    schedule          = "${var.ebs_backup["schedule"]}"
+
+    lifecycle = {
+      cold_storage_after = "${var.ebs_backup["cold_storage_after"]}"
+      delete_after       = "${var.ebs_backup["delete_after"]}"
+    }
+  }
+
+  tags = "${merge(local.tags, map("Name", "${var.environment_name}-${var.project_name}-iapsbkup-pri-pln"))}"
+}
+
+resource "aws_backup_selection" "iaps_backup_selection" {
+  iam_role_arn = "${local.backup_ebs_role_arn}"
+  name         = "${var.environment_name}-${var.project_name}-iapsabkup-pri-sel"
+  plan_id      = "${aws_backup_plan.iaps_backup_plan.id}"
+
+  selection_tag {
+    type  = "STRINGEQUALS"
+    key   = "Name"
+    value = "${var.environment_name}-${var.project_name}-iaps-ebs"
+  }
+}

--- a/ec2/main.tf
+++ b/ec2/main.tf
@@ -5,7 +5,7 @@ terraform {
 
 provider "aws" {
   region  = "${var.region}"
-  version = "~> 1.16"
+  version = "~> 2.17"
 }
 
 ####################################################
@@ -68,25 +68,28 @@ data "terraform_remote_state" "security-groups" {
 #-------------------------------------------------------------
 data "aws_ami" "amazon_ami" {
   most_recent = true
+  owners      = ["895523100917"]
 
   filter {
     name   = "name"
     values = ["HMPPS IAPS Windows Server master*"]
   }
 
+  # correct arch
   filter {
     name   = "architecture"
     values = ["x86_64"]
   }
 
+  # Owned by Amazon
   filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
+    name   = "owner-id"
+    values = ["895523100917"]
   }
 
   filter {
-    name   = "root-device-type"
-    values = ["ebs"]
+    name   = "virtualization-type"
+    values = ["hvm"]
   }
 }
 
@@ -113,4 +116,5 @@ locals {
   sg_lb_external_id            = "${data.terraform_remote_state.security-groups.security_groups_sg_external_lb_id}"
   private_subnet_ids           = ["${data.terraform_remote_state.common.private_subnet_ids}"]
   public_subnet_ids            = ["${data.terraform_remote_state.common.public_subnet_ids}"]
+  backup_ebs_role_arn          = "${data.terraform_remote_state.iam.backup_ebs_role_arn}"
 }

--- a/ec2/output.tf
+++ b/ec2/output.tf
@@ -3,8 +3,8 @@ output "iaps_asg_arn" {
   value = "${aws_autoscaling_group.iaps.arn}"
 }
 
-output "iaps_launchconfig_id" {
-  value = "${aws_launch_configuration.iaps.id}"
+output "iaps_launchtemplate_id" {
+  value = "${aws_launch_template.iaps.id}"
 }
 
 output "iaps_alb_arn" {

--- a/ec2/variables.tf
+++ b/ec2/variables.tf
@@ -12,6 +12,20 @@ variable "instance_type" {
   default = "t3.medium"
 }
 
+variable "ebs_volume_size" {
+  default = 30
+}
+
+variable "ebs_backup" {
+  type = "map"
+
+  default = {
+    schedule           = "cron(0 04 * * ? *)"
+    cold_storage_after = 14
+    delete_after       = 120
+  }
+}
+
 variable "environment_name" {
   type = "string"
 }

--- a/iam/main.tf
+++ b/iam/main.tf
@@ -78,3 +78,18 @@ module "create-iam-app-policy-int" {
   policyfile = "${data.template_file.iam_policy_app_int.rendered}"
   rolename   = "${module.create-iam-app-role-int.iamrole_name}"
 }
+
+# AWS Backups IAM role for EFS Data Volume
+data "template_file" "backup_assume_role_template" {
+  template = "${file("../policies/backup_assume_role.tpl")}"
+  vars     = {}
+}
+resource "aws_iam_role" "iaps_ebs_backup_role" {
+  name               = "${local.common_name}-iapsbkup-pri-iam"
+  assume_role_policy = "${data.template_file.backup_assume_role_template.rendered}"
+}
+
+resource "aws_iam_role_policy_attachment" "iaps_ebs_backup_policy" {
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForBackup"
+  role       = "${aws_iam_role.iaps_ebs_backup_role.name}"
+}

--- a/iam/output.tf
+++ b/iam/output.tf
@@ -16,3 +16,7 @@ output "iam_policy_sim_app_role_arn" {
 output "iam_policy_sim_app_instance_profile_name" {
   value = "${module.create-iam-instance-profile-int.iam_instance_name}"
 }
+
+output "backup_ebs_role_arn" {
+  value = "${aws_iam_role.iaps_ebs_backup_role.arn}"
+}

--- a/policies/backup_assume_role.tpl
+++ b/policies/backup_assume_role.tpl
@@ -1,0 +1,16 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "ec2.amazonaws.com",
+          "backup.amazonaws.com"
+        ]
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}


### PR DESCRIPTION
adds an iam role for aws backups
switches from launch_configuration to launch_template to allow ebs vols to be tagged as well as ec2 instances
creates an aws backup job based on the iaps ebs volume name tags 
closes #25 